### PR TITLE
イラストカタログの取得先をApps Scriptのデプロイ URL に修正

### DIFF
--- a/sample-spring-boot-echo/src/main/java/com/example/bot/common/CommonModule.java
+++ b/sample-spring-boot-echo/src/main/java/com/example/bot/common/CommonModule.java
@@ -33,7 +33,19 @@ import lombok.extern.slf4j.Slf4j;
 public class CommonModule {
 
   private static final RestTemplate restTemplate = new RestTemplate();
-  private static final String URL = "https://script.googleusercontent.com/macros/echo?user_content_key=aKMvG1GRG6CYrznJw6x0cjbGjD3XCu6DkIARkCZYZB257AnrACX_SIEBnxtbI7z26GYt4zejEm13dha_xv4o3wgiVNcAjd6_m5_BxDlH2jW0nuo2oDemN9CCS2h10ox_1xSncGQajx_ryfhECjZEnCNpoqCEl5Y_84RG7F4nLvpUk-DyE4X5eE_1h0yajhEvYBr9Jf8qIeO625quMX_ShEW-dnclfdIe&lib=Mc3tlEOHbGs_amoROLTGc0nOYk-y_j7OD";
+
+  /**
+   * イラスト一覧を返すGoogle Apps ScriptのウェブアプリURL.
+   *
+   * <p>必ずデプロイURL（{@code /macros/s/<デプロイID>/exec}）を指定する。
+   * ブラウザでこのURLを開くと{@code script.googleusercontent.com/macros/echo}へ
+   * 302で転送されるが、転送先の{@code user_content_key}は一時的な発行物で
+   * いずれ失効し、以降は400を返し続ける。転送先URLを貼ってはならない。
+   * GETのリダイレクト追跡は{@link RestTemplate}の既定動作で行われる。
+   */
+  static final String URL =
+      "https://script.google.com/macros/s/"
+      + "AKfycbyy5RZiz_11ylnVV4NB4kToZv6Qv9ecXkxRgnWo9yvE_AxNLvM/exec";
   private static Map<String, ArrayList<Integer>> illustrationRtioMap;
   private static Map<String, ArrayList<String>> illustrationUrlMap;
 

--- a/sample-spring-boot-echo/src/test/java/com/example/bot/common/CommonModuleTest.java
+++ b/sample-spring-boot-echo/src/test/java/com/example/bot/common/CommonModuleTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.example.bot.common;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.example.bot.staticdata.MessageConst;
+
+/**
+ * イラストカタログの取得先と、取得できない場合の挙動を固定する.
+ *
+ * <p>ネットワークへは出ない。実際の取得は{@code @Scheduled}から行われる。
+ */
+public class CommonModuleTest {
+
+  /**
+   * 取得先はデプロイURLでなければならない.
+   *
+   * <p>{@code /exec}をブラウザで開くと{@code script.googleusercontent.com/macros/echo}へ
+   * 転送される。その転送先URLを貼ると、{@code user_content_key}の失効後に400を返し続け、
+   * イラストが固定画像へ落ちたまま戻らなくなる。過去に実際に発生している。
+   */
+  @Test
+  public void catalogUrlIsADeploymentUrlNotItsRedirectTarget() {
+    assertTrue("デプロイURLを指定すること: " + CommonModule.URL,
+        CommonModule.URL.startsWith("https://script.google.com/macros/s/"));
+    assertTrue("デプロイURLは/execで終わる: " + CommonModule.URL,
+        CommonModule.URL.endsWith("/exec"));
+    assertFalse("転送先URLはuser_content_keyが失効するため使えない: " + CommonModule.URL,
+        CommonModule.URL.contains("googleusercontent.com"));
+  }
+
+  /** カタログを取得できていない間は、MessageConstの固定画像へ落とす. */
+  @Test
+  public void fallsBackToTheFixedIllustrationWhileTheCatalogIsUnavailable() {
+    assertEquals(MessageConst.INSIDER_URL, CommonModule.getIllustUrl("INSIDER"));
+    assertEquals(MessageConst.VILLAGERS_URL, CommonModule.getIllustUrl("VILLAGERS"));
+    assertEquals(MessageConst.GM_URL, CommonModule.getIllustUrl("GM"));
+    assertEquals(MessageConst.GOD_URL, CommonModule.getIllustUrl("GOD"));
+  }
+}


### PR DESCRIPTION
## 症状

Google ドライブから取得していたイラストが表示されなくなり、`MessageConst` の固定画像のみになっていた。

## 原因

`CommonModule.URL` に、ウェブアプリ本体ではなく**リダイレクト先**のURLが入っていた。

`/exec` をブラウザで開くと `script.googleusercontent.com/macros/echo?user_content_key=...` へ302で転送される。この `user_content_key` はリクエストごとに発行される一時的な値で、いずれ失効する。失効後は毎回 400 が返り、`getIllustUrl` が固定画像へフォールバックし続けていた。

本番ログ:

```
INFO  [scheduling-1] EchoApplication : Refreshing illustration catalog
WARN  [scheduling-1] CommonModule    : Failed to refresh the illustration catalog
org.springframework.web.client.HttpClientErrorException$BadRequest: 400 Bad Request
    at CommonModule.createMap(CommonModule.java:80)
```

### なぜ直前のマージ後に顕在化したか

`createMap()` は**成功時にしかマップを代入しない**。失敗しても前回の値が static フィールドに残るため、プロセスが生きている限り最後に取得できたスナップショットで画像が出続けていた。#3 のマージに伴う再デプロイで JVM が再起動し、マップが null に戻ったことで表面化した。

#3 のコード変更が原因ではない。該当パスの差分はログ出力のみで、`@Scheduled` ブロックは前後で同一。Heroku の dyno は日次で再起動するため、マージがなくても遅くとも翌日には同じ状態になっていた。

## 修正

- 取得先を安定した `/exec` デプロイURLへ変更
- 転送先URLを貼ってはならない理由を javadoc に明記
- URLの形をピン留めするテストを追加（旧URLを入れると落ちることを確認済み）

`RestTemplate` は GET でリダイレクトを追跡するため（`SimpleClientHttpRequestFactory` が `setInstanceFollowRedirects(true)` を設定、バイトコードで確認）、転送自体にコード変更は不要。

## 検証

新URLへ実際にアクセスして確認:

| 項目 | 結果 |
|---|---|
| `/exec` へのGET | 200 / `application/json; charset=utf-8` |
| `lib=` パラメータ | 旧URLと同一（同じスクリプトのキーのみ失効と確定） |
| ファイル数 | 45件 |
| カタログ全体の構築を中断させる不正なファイル名 | 0件 |
| 役職の網羅 | GM 7 / GOD 4 / INSIDER 17 / VILLAGERS 17、欠けなし |
| 画像の匿名取得 | 4役職とも 200 / `image/png` / 720x480 / 最大693KB |

LINE の要件（HTTPS・PNG・幅1024px以下・1MB以下）を満たしている。`./gradlew check` は 63 tests / 0 failures。

デプロイ後、次のスケジュール実行（最大5分）で復旧する。

## レビュー時に知っておくとよいこと

このURLは「全員」公開で運用しているウェブアプリのものなので、設計上パブリックであり秘匿情報ではない。

本PRに**含めていない**既知の改善点:

1. 起動直後に1回取得する処理がない。再起動のたび最大5分間、必ず固定画像になる
2. ファイル名の2番目が数字でないファイルが1つでもあると `Integer.parseInt` の例外が外側の catch まで飛び、カタログ構築ごと中断する（現時点で該当ファイルはないが、1件混入するだけで全役職が固定画像に落ちる）
3. マップが null 初期化のため、`getIllustUrl` は NPE を `catch (Exception)` で拾う形になっており、本物の障害と区別がつかない

復旧を優先して分離した。別PRで対応可能。